### PR TITLE
fix(breadcrumbs): correct aria label placement

### DIFF
--- a/layer/components/Breadcrumbs.vue
+++ b/layer/components/Breadcrumbs.vue
@@ -10,21 +10,20 @@ useSchemaOrg([
 </script>
 
 <template>
-  <ul
-    v-if="breadcrumbs.length > 1"
-    aria-label="Breadcrumb"
-  >
-    <template
-      v-for="(item, key) in breadcrumbs"
-      :key="key"
-    >
-      <li>
-        <slot name="breadcrumb" :to="item.to" :title="item.title" :last="key === breadcrumbs.length - 1" :first="key === 0">
-          <NuxtLink :to="item.to">
-            {{ item.title }}
-          </NuxtLink>
-        </slot>
-      </li>
-    </template>
-  </ul>
+  <nav aria-label="Breadcrumb">
+    <ul v-if="breadcrumbs.length > 1">
+      <template
+        v-for="(item, key) in breadcrumbs"
+        :key="key"
+      >
+        <li>
+          <slot name="breadcrumb" :to="item.to" :title="item.title" :last="key === breadcrumbs.length - 1" :first="key === 0">
+            <NuxtLink :to="item.to">
+              {{ item.title }}
+            </NuxtLink>
+          </slot>
+        </li>
+      </template>
+    </ul>
+  </nav>
 </template>


### PR DESCRIPTION
### Description

https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/ shows valid `aria-label` usage for breadcrumbs.

### Linked Issues
Resolves #33