### PR TITLE
add showAtRoot to breadcrumbs component props

### DIFF
--- a/layer/components/Breadcrumbs.vue
+++ b/layer/components/Breadcrumbs.vue
@@ -1,4 +1,9 @@
 <script lang="ts" setup>
+interface BreadcrumbsProps {
+  showAtRoot: boolean
+}
+
+defineProps<BreadcrumbsProps>()
 const breadcrumbs = useBreadcrumbs()
 const schemaBreadcrumbs = computed(() => breadcrumbs.value.map(breadcrumb => breadcrumb.schema))
 
@@ -11,7 +16,7 @@ useSchemaOrg([
 
 <template>
   <nav aria-label="Breadcrumb">
-    <ul v-if="breadcrumbs.length > 1">
+    <ul v-if="showAtRoot || breadcrumbs.length > 1">
       <template
         v-for="(item, key) in breadcrumbs"
         :key="key"


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

There's a design decision for one of websites I'm working on that says I have to include the breadcrumb everywhere, including the main page, but it's currently not possible
this aims to add that feature

### Linked Issues

searched, couldn't find related issue

### Additional context

there's also a need for i18n support, which I copied the composable to my project and edited it
I'll make another PR on top of this one, if you liked it you can merge :)
