### PR TITLE
fix(components): remove unused parameter

### DIFF
--- a/module/src/runtime/components/SeoKit.vue
+++ b/module/src/runtime/components/SeoKit.vue
@@ -1,16 +1,5 @@
 <script lang="ts" setup>
-import { useSeoKit } from '#imports'
-
-const props = defineProps<{
-  siteUrl?: string
-  siteName?: string
-  siteDescription?: string
-  siteImage?: string
-  titleSeparator?: string
-  language?: string
-}>()
-
-useSeoKit(props)
+useSeoKit()
 </script>
 
 <template>


### PR DESCRIPTION
### Description

Just a quick PR. I noticed that `useSeoKit` does currently not accept a parameter. This results in a linting error for me. Please simply close this PR if it's intended to give `useSeoKit` a parameter instead :)

### Linked Issues

n/a

### Additional context

I'm wondering why `nuxt typecheck` complains about this in v2-beta.6 and not in v2-beta.5 :thinking: As far as I see this particular code did not change?
