### PR TITLE
docs: add missing prefix to Customizing UI page

### DIFF
--- a/docs/content/5.sitemap/2.guides/6.customising-ui.md
+++ b/docs/content/5.sitemap/2.guides/6.customising-ui.md
@@ -48,7 +48,7 @@ export default defineNuxtConfig({
   sitemap: {
     xslColumns: [
       { label: 'URL', width: '50%' },
-      { label: 'Last Modified', select: 'lastmod', width: '25%' },
+      { label: 'Last Modified', select: 'sitemap:lastmod', width: '25%' },
       { label: 'Priority', select: 'sitemap:priority', width: '12.5%' },
       { label: 'Change Frequency', select: 'sitemap:changefreq', width: '12.5%' },
     ],


### PR DESCRIPTION
Add missing prefix to Customizing UI page

### Description

This commit adds missing prefix `sitemap:` to the [Customizing UI](https://nuxtseo.com/sitemap/guides/customising-ui) page of the `nuxt-simple-sitemap` documentation.