### PR TITLE
docs: backtick render error

### DIFF
--- a/docs/content/2.sitemap/4.api/0.config.md
+++ b/docs/content/2.sitemap/4.api/0.config.md
@@ -155,7 +155,7 @@ The storage engine to use for the cache. See [Caching](/sitemap/guides/caching) 
 
 ## `xslColumns`
 
-- Type: `({ label: string; width: `${string}%`; select?: string })[]`
+- Type: ``({ label: string; width: `${string}%`; select?: string })[]``
 - Default: 
 ```json
 [


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The v2 config README is not rendering correctly when you have backtick inside backtick

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
