### PR TITLE
fix(module): alias `@unhead/vue`

### DIFF
--- a/module/src/module.ts
+++ b/module/src/module.ts
@@ -5,6 +5,7 @@ import {
   createResolver,
   defineNuxtModule,
   installModule,
+  tryResolveModule,
   useLogger,
 } from '@nuxt/kit'
 import chalk from 'chalk'
@@ -112,7 +113,12 @@ export default defineNuxtModule<ModuleOptions>({
         })
       }
     }
+
+    // `headNext` enables `@unhead/vue` usage, which must be aliased
     nuxt.options.experimental.headNext = true
+    const unheadVue = await tryResolveModule('@unhead/vue', nuxt.options.modulesDir)
+    if (!unheadVue) throw new Error(`Could not resolve module "@unhead/vue"`)
+    nuxt.options.alias['@unhead/vue'] = unheadVue
 
     // add redirect middleware
     if (config.redirectToCanonicalSiteUrl) {


### PR DESCRIPTION
### Description

As this module in v2 turns on Nuxt's experimental feature `headNext` which uses `@unhead/vue`, that module needs to be aliased for usage **without** `shamefully-hoist`, I think.

Resolves https://stackblitz.com/edit/github-ta4wyu?file=nuxt.config.ts

### Linked Issues

https://github.com/nuxt/nuxt/issues/14146

### Additional context

Or should this better be implemented in Nuxt itself? cc @danielroe
