### PR TITLE
chore(package): rework build scripts

### DIFF
--- a/module/package.json
+++ b/module/package.json
@@ -26,7 +26,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "nuxt-module-build --stub && nuxt-module-build prepare && nuxt-module-build"
+    "build": "nuxt-module-build build",
+    "prepack": "pnpm run build"
   },
   "dependencies": {
     "@nuxt/kit": "^3.7.4",


### PR DESCRIPTION
### Description

- `pnpm run build` should run before `pnpm pack`, I'd say
- I think `nuxt-module-build --stub && nuxt-module-build prepare` is unnecessary if `nuxt-module-build` runs afterall
- `nuxt-module-build` wants `build` to be specified as subcommand now

### Linked Issues

n/a

### Additional context

Not sure if using `nuxi build-module` is even a better style. @pi0 any advice?
