### PR TITLE
doc: fix typo

### DIFF
--- a/docs/content/0.nuxt-seo/2.guides/1.title-templates.md
+++ b/docs/content/0.nuxt-seo/2.guides/1.title-templates.md
@@ -19,7 +19,7 @@ The following tokens are available out-of-the-box:
 - `%site.name` - The name of your site.
 - `%site.url` - The canonical URL of your site.
 - `%s` or `%pageTitle` - The page title, without the template
-- `%separator` - Speical token used to seperate parts of your title. These have special behavior in that
+- `%separator` - Special token used to seperate parts of your title. These have special behavior in that
 they will be logically removed when it makes sense. See [Seperator](https://unhead.unjs.io/usage/guides/template-params) for more details.
 
 These tokens are available not only for the title, but also:


### PR DESCRIPTION
### Issue : 
I just spot an error on https://nuxtseo.com/nuxt-seo/guides/title-templates 

### Fix : 
Change `Speical` for `Special` 