### PR TITLE
docs: update components title

### DIFF
--- a/docs/content/3.og-image/3.api/2.components.md
+++ b/docs/content/3.og-image/3.api/2.components.md
@@ -1,5 +1,5 @@
 ---
-title: Composables
+title: Components
 ---
 
 Coming soon.


### PR DESCRIPTION
### Description
This PR fixes a typo where `components.md` has the title "Composables".

This leads to the side nav showing the incorrect page title:

<img width="248" alt="image" src="https://github.com/harlan-zw/nuxt-seo-kit/assets/70809675/e9408cb0-f421-4821-8bc6-019bc14d2df7">

Just a small thing that confused me, so I decided to edit and submit this PR. Thank you for your work 🙏