### PR TITLE
docs(sitemap): link `defineRouteRules`

### DIFF
--- a/docs/content/2.sitemap/2.guides/0.filtering-urls.md
+++ b/docs/content/2.sitemap/2.guides/0.filtering-urls.md
@@ -31,7 +31,7 @@ export default defineNuxtConfig({
 
 ### Disabling indexing for a Page
 
-If you just have some specific pages, you can use the `defineRouteRule`
+If you just have some specific pages, you can use the experimental [`defineRouteRules`](https://nuxt.com/docs/api/utils/define-route-rules)
 
 ```vue
 <script setup>


### PR DESCRIPTION
### Description

Link `defineRouteRules`, adding the trailing `s`.

### Linked Issues

n/a

### Additional context

n/a
